### PR TITLE
Correct Clash binary version and fix TUN not finding interface after WAN IP is changed

### DIFF
--- a/plugins/clash.inc
+++ b/plugins/clash.inc
@@ -26,6 +26,14 @@ function clash_services()
 
     return $services;
 }
+
+function clash_configure()
+{
+    return [
+        'newwanip' => ['clash_restart'],
+    ];
+}
+
 function clash_syslog()
 {
     $logfacilities = array();
@@ -33,4 +41,10 @@ function clash_syslog()
         'facility' => array('clash'),
     );
     return $logfacilities;
+}
+
+
+function clash_restart()
+{
+    exec('sh /usr/local/etc/rc.d/clash restart');
 }


### PR DESCRIPTION
1. The Clash binary in the current main branch and the 1.12 release is the wrong version - v1.18.7. I have changed the binary to v1.19.17-vincent.

2. Clash reported "[TUN]: cannot find interface" after WAN IP is change via a PPPoE renewal. I didn't find a good way to change the interface IP used by Clash on the fly, so I configured clash to be restarted by hooking the restart to the newwanip event.